### PR TITLE
Added saving images from different threads into different folders

### DIFF
--- a/Scrape.py
+++ b/Scrape.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 import json, urllib, urllib.request, urllib.error, urllib.parse, os, time
 from queue import Queue
 from threading import Thread
@@ -42,7 +43,8 @@ class JsonWorker():
 	# Returns the filepath string to the directory to store the files.
 	#TODO --- Move creating the directory to its own class function
 	def getPath(self):
-		location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+		location=os.path.realpath(os.getcwd())
+		#location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 		if not args.d:
 			path = location + "/imgs/"
 		else:

--- a/Scrape.py
+++ b/Scrape.py
@@ -22,11 +22,13 @@ class DownloadWorker(Thread):
 			download_image(filename, board)
 			self.queue.task_done()
 
+# Class made to handle JSON operations. Should allow more extensibility
 class JsonWorker():
 	def __init__(self, json_data):
 		self.json_data=json_data
 		self.img_URLS=[]
 	
+	# Simply returns the list of file URLs. Most code taken from pull_image_urls function
 	def getImageURLs(self):
 		noPosts = len(self.json_data)
 		for x in range(0, noPosts):
@@ -37,16 +39,19 @@ class JsonWorker():
 		print(str(len(self.img_URLS)) + " Images Found")
 		return self.img_URLS
 
+	# Returns the filepath string to the directory to store the files.
+	#TODO --- Move creating the directory to its own class function
 	def getPath(self):
 		location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 		if not args.d:
 			path = location + "/imgs/"
 		else:
+			# Prioritizing the thread subject, then part of the comment
 			if self.json_data[0].get('sub') is not None:
 				path=location+"/"+self.json_data[0].get('sub')+"/"
 			elif self.json_data[0].get('com') is not None:
 				try:
-					path=location+'/'+json_data[0].get('com')[:49]+'/'
+					path=location+'/'+self.json_data[0].get('com')[:49]+'/'
 				except:
 					path=location+'/imgs/'
 		try:
@@ -60,7 +65,6 @@ class JsonWorker():
 
 img_URLS = []
 path=''
-# fallbackpath=os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))+"/imgs/"
 invalid_link = True
 run = True
 
@@ -117,7 +121,6 @@ def pull_image_urls(url, board):
 		print(e.args)
 		return
 
-	print('handling json')
 	JSON=JsonWorker(json_data)
 	global img_URLS
 	img_URLS=JSON.getImageURLs()
@@ -126,10 +129,7 @@ def pull_image_urls(url, board):
 
 def download_image(img_URL, board):
 	image = urllib.request.urlopen("http://i.4cdn.org/" + board + "/" + img_URL)
-	# try:
 	file = open(path + img_URL, "wb")
-	# except FileNotFoundError as e: #should prevent issues with illegal filenames
-	# 	file= open(fallbackpath+img_URL,"wb")
 	file.write(image.read())
 
 

--- a/Scrape.py
+++ b/Scrape.py
@@ -44,6 +44,7 @@ class JsonWorker():
 	#TODO --- Move creating the directory to its own class function
 	def getPath(self):
 		location=os.path.realpath(os.getcwd())
+		global folder_increment
 		#location = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 		if not args.d:
 			path = location + "/imgs/"
@@ -55,17 +56,20 @@ class JsonWorker():
 				try:
 					path=location+'/'+self.json_data[0].get('com')[:49]+'/'
 				except:
-					path=location+'/imgs/'
+					path=location+'/imgs'+str(folder_increment)+'/'
+					folder_increment+=1
 		try:
 			if not os.path.exists(path):  
 				os.mkdir(path)
 		except FileNotFoundError as e: #should prevent issues with illegal filename characters + length
-			path=location+'/imgs/'
+			path=location+'/imgs'+str(folder_increment)+'/'
+			folder_increment+=1
 			if not os.path.exists(path):  
 				os.mkdir(path)
 		return path
 
 img_URLS = []
+folder_increment=0
 path=''
 invalid_link = True
 run = True


### PR DESCRIPTION
Added option to have different threads have their own folders for placing images. Runs the same as before without the -d option. Should hopefully not crash as it required heavy changes to the code.


Cleaned up some code, added some comments on JsonWorker class, fixed issue allowing comments to be the directory name

Image directories are now made in current working directly rather than the directory where Scrape.py is. Not sure how this will affect when running with the .bat file.